### PR TITLE
fix: on changes update data attributes

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -13,7 +13,7 @@ const bindFn: DirectiveFunction = (el, binding) => {
   }
 };
 
-const vEditableDirective = { bind: bindFn };
+const vEditableDirective = { bind: bindFn, update: bindFn };
 
 let storyblokApiInstance: StoryblokClient = null;
 export const useStoryblokApi = () => {


### PR DESCRIPTION
We have what seems to be a unique use case. We are statically generating our pages before deploying using the published version of a story. The published version of the story does not include the `_edtiable` key in it. The result is static HTML that contains things like this:

```html
<div data-blok-c="undefined" data-blok-uid="undefined" class="storyblok__outline" ...
```

On these static pages we accept a query parameter `?preview=true` that changes the behavior of the page. It still loads with the published version but then makes a request for the draft version and updates the DOM.

The change purposed here is to pick up on that switch from published to draft and make sure the `data-block` attributes are updated. I have tested this change and we are actively using it in production today.