### PR TITLE
chore: add groups for our most common dependencies types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,16 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
+    groups:
+      linting-dx-tools:
+        patterns:
+          - "*lint*" # eslint, eslint-*, vue-eslint-parser, lint-staged, @commitlint/*, @typescript-eslint/*
+          - "prettier"
+          - "husky"
+          - "@vue/tsconfig"
+      testing-tools:
+        patterns:
+          - "vitest"
+          - "cypress"
+          - "@cypress/*"
+          - "@vue/test-utils"


### PR DESCRIPTION
Including Dependabot groups for improving the way we update dependencies.